### PR TITLE
Normalize relay hint urls

### DIFF
--- a/build-gh-pages.sh
+++ b/build-gh-pages.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -e
+current_branch=$(git symbolic-ref --short HEAD)
+echo "currently on branch: $current_branch"
+if ! git diff-index --quiet HEAD --; then
+echo "Error: There are modified or uncommitted files. Please commit or stash changes first."
+exit 1
+fi
+if git worktree list | grep -q ./gh-pages; then
+git worktree remove ./gh-pages
+git branch -D gh-pages
+fi
+git checkout --orphan gh-pages
+git rm -rf .
+echo "gh-pages branch" > README.md
+git add README.md
+git commit -m "initialize gh-pages branch"
+git checkout "$current_branch"
+git worktree add ./gh-pages gh-pages
+cd gh-pages && mkdir -p ./target/esbuild
+cp ../index.html ./
+cp ../favicon.ico ./
+cp ../edit.svg ./
+cp ../ext.svg ./
+cp ../target/esbuild/bundle.js ./target/esbuild
+git add .
+git commit -m "update gh-pages branch with new built site"
+cd ..
+echo "done building gh-pages branch"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1738142207,
+        "narHash": "sha256-NGqpVVxNAHwIicXpgaVqJEJWeyqzoQJ9oc8lnK9+WC4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "9d3ae807ebd2981d593cddd0080856873139aa40",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,50 @@
+{
+  description = "A Nix-flake-based Scala development environment";
+  
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  outputs = { self, nixpkgs }:
+    let
+      javaVersion = 17; # Change this value to update the whole stack
+
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forEachSupportedSystem = f: nixpkgs.lib.genAttrs supportedSystems (system: f {
+        pkgs = import nixpkgs { inherit system; overlays = [ self.overlays.default ]; };
+      });
+
+
+    in
+    {
+      overlays.default = final: prev:
+        let
+          jdk = prev."jdk${toString javaVersion}";
+        in
+        {
+          sbt = prev.sbt.override { jre = jdk; };
+          scala = prev.scala_3.override { jre = jdk; };
+        };
+
+      devShells = forEachSupportedSystem ({ pkgs }: {
+        default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            stdenv
+            sbt
+            openjdk
+            boehmgc
+            libunwind
+            clang
+            zlib
+            secp256k1
+            nodejs
+            yarn 
+            just
+          ];
+          packages = with pkgs; [ 
+            scala 
+            sbt 
+            coursier 
+            scala-cli 
+          ];
+        };
+      });
+    };
+}

--- a/index.html
+++ b/index.html
@@ -1,7 +1,8 @@
 <meta charset=utf-8>
 <title>nostr army knife</title>
 <script src="https://cdn.tailwindcss.com"></script>
+<link rel="icon" type="image/x-icon" href="./favicon.ico">
 <body class="bg-emerald-200 text-black m-0 w-full h-full">
   <div id="app" class="w-full h-full"></div>
-  <script type="module" src="/target/esbuild/bundle.js"></script>
+  <script type="module" src="./target/esbuild/bundle.js"></script>
 </body>

--- a/justfile
+++ b/justfile
@@ -11,3 +11,9 @@ cloudflare:
     rm -fr cf
 
 build-and-deploy: build-prod cloudflare
+
+build-gh-pages: build-prod
+    ./build-gh-pages.sh
+
+
+        

--- a/src/main/scala/Components.scala
+++ b/src/main/scala/Components.scala
@@ -471,6 +471,6 @@ object Components {
       )
     )
 
-  private val edit = img(cls := "inline w-4 ml-2", src := "edit.svg")
-  private val external = img(cls := "inline w-4 ml-2", src := "ext.svg")
+  private val edit = img(cls := "inline w-4 ml-2", src := "./edit.svg")
+  private val external = img(cls := "inline w-4 ml-2", src := "./ext.svg")
 }

--- a/src/main/scala/Components.scala
+++ b/src/main/scala/Components.scala
@@ -403,9 +403,15 @@ object Components {
                       // confirm adding a relay hint
                       evt.key match {
                         case "Enter" =>
-                          self.value.get.flatMap(url =>
-                            if url.startsWith("wss://") || url
-                                .startsWith("ws://")
+                          self.value.get
+                          .map{
+                            case url if url.isEmpty => url
+                            case url if url.contains("://") => url
+                            case url if !url.contains("://") && url.nonEmpty => url.prependedAll("wss://")
+                            case _ => ""
+                          }
+                          .flatMap(url =>
+                            if url.contains("://")
                             then {
                               store.result.get.flatMap(result =>
                                 store.input.set(

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -25,7 +25,7 @@ object Main extends IOWebApp {
             cls := "px-1 py-2 text-center text-xl",
             img(
               cls := "inline-block w-8 mr-2",
-              src := "/favicon.ico"
+              src := "./favicon.ico"
             ),
             a(
               href := "/",


### PR DESCRIPTION
This did not require rebuilding `snow` or upgrading scala versions, so I just kept it simple. When adding a relay hint to an `nevent`, unless the hint already has a `://` in it, it will now default to `wss://`. So if the hint `abc.com` is provided, it will be rewritten to `wss://abc.com`, but if `ws://abc.com` is provided it will be kept as is. 

And on the very odd chance that relay hints eventually end up using some other protocol, this tool will still work: it will not rewrite a hint of `ftp://abc.com` but rather simply assumes the user must know what they are doing (it is an army knife after all!) :-P

Lastly, I was doing testing with gh-pages, so added a little script to help with that. For gh-pages to work properly, we needed relative links in the various assets (favicon.ico, etc). 