### PR TITLE
nip19: nevents encoded/decoded with optional kind

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,13 @@
 enablePlugins(ScalaJSPlugin, EsbuildPlugin)
 
 name := "nostr-army-knife"
-scalaVersion := "3.3.0-RC4"
+scalaVersion := "3.3.4"
 
 lazy val root = (project in file("."))
   .settings(
     libraryDependencies ++= Seq(
       "com.armanbilge" %%% "calico" % "0.2.0-RC2",
-      "com.fiatjaf" %%% "snow" % "0.0.1"
+      "com.fiatjaf" %%% "snow" % "0.0.2-SNAPSHOT"
     ),
     scalaJSUseMainModuleInitializer := true,
     scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) }

--- a/src/main/scala/Components.scala
+++ b/src/main/scala/Components.scala
@@ -110,6 +110,9 @@ object Components {
       evp.author.map { pk =>
         entry("author (pubkey hex)", pk.value.toHex)
       },
+      evp.kind.map { kind => 
+        entry("kind", kind.toString)
+      },
       nip19_21(store, "nevent", NIP19.encode(evp)),
       entry(
         "note",
@@ -270,7 +273,7 @@ object Components {
         nip19_21(
           store,
           "nevent",
-          NIP19.encode(EventPointer(id, author = event.pubkey))
+          NIP19.encode(EventPointer(id, author = event.pubkey, kind = Some(event.kind)))
         )
       ),
       if event.kind >= 30000 && event.kind < 40000 then


### PR DESCRIPTION
This depends on the [changes made to snow](https://github.com/fiatjaf/snow/compare/master...VzxPLnHqr:make-snow-great-again?expand=1).

In the interim, you can copy/paste 
`nevent1qqsz82w5x45pm8z9sj9vtjs7m5uht5jkjp4pt06dyfqp56me398vglszyqkmuzfvdtdpxelvkuaqaugu6tp3l6ejx4uzf3j2rrud4pvky9xhqqgvwaehxw309auzucm0d5hszrthwden5te0venxwtnrdaksxpqqqqqqz9d45p7` into https://vzxplnhqr.github.io/nak-web/ and it should show that the `nevent` has `kind 1`.