### PR TITLE
url parameter passed to input text area

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ scalaVersion := "3.3.4"
 lazy val root = (project in file("."))
   .settings(
     libraryDependencies ++= Seq(
-      "com.armanbilge" %%% "calico" % "0.2.0-RC2",
+      "com.armanbilge" %%% "calico" % "0.2.3",
       "io.github.vzxplnhqr" %%% "snow" % "0.0.5"
     ),
     scalaJSUseMainModuleInitializer := true,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.16.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.17.0")
 addSbtPlugin("com.fiatjaf" % "sbt-esbuild" % "0.1.1")


### PR DESCRIPTION
This is a first pass at making the url parameter sync with the input text area.  For example, loading up https://vzxplnhqr.github.io/nak-web/#/nprofile1qqsxn8j0fq39yzh2u5almczalaklsun2eslr5ccwa5sh08pna77u34qpz9mhxue69uhkv6tpw34xze3wvdhk6y86xpe will put `nprofile1qqsxn8...` in the text area, and whenever the input changes, the url is updated. 